### PR TITLE
Feature/hwf add comments for yes partial no in module 3

### DIFF
--- a/HWF/Custom_forms/NHWA Module 3 (gUsLcRFoCG6).html
+++ b/HWF/Custom_forms/NHWA Module 3 (gUsLcRFoCG6).html
@@ -98,18 +98,76 @@
       "IS6oWwtsElu",
       "S0cJazBoB9r",
       "ZVZnw9CazmI",
-      "RBkF8N37tQl"
+      "RBkF8N37tQl",
+      "xIdJZgy5GSy",
+      "oTTeFlxkljB",
+      "TVuwNm1PyRC",
+      "SUvvKWCJO5S",
+      "GRpQAAvLFM6",
+      "Bvwo2Tnwg6K",
+      "BAYPJS2PaYa",
+      "AuztI35M2eU",
+      "CHeEETUlnlu",
+      "hUTcFeRUFve",
+      "aNkwiAZwM7f",
+      "adhcUwpwjrt",
+      "EUuaZTsVCUP",
+      "HHu5mmkn9nI",
+      "SvnuCPrV3m8",
+      "M09xmOtGx9r",
+      "W1nqjNXF8t7",
+      "vVPyD60zs2c",
+      "qDrIfDpZQzJ",
+      "oBOgUPGLDM8",
+      "K9YrD3rxhIm",
+      "s6Rrf01L045",
+      "KI35YVBqwOH",
+      "Iz9uNISIBW5",
+      "BABcY9z1yhJ",
+      "kf5mAEgzRro",
+      "Px7yHDZGBQS",
+      "Jo5JCqQn6a4",
+      "HfUw03ynsgX",
+      "FbLuOUxYtvW",
+      "sIxOvk6qfU2",
+      "dNdiNzgxEAO",
+      "H7lhdWUUWxH",
+      "grFSq6NI6Rv",
+      "d5tEbnmf2Yl",
+      "zJNTztzEUjf",
+      "klUdBljsnYT",
+      "Ye7wRY6LeT4",
+      "OJ2BPEwWYG9",
+      "el5QnfrCW5R",
+      "w3Lz42yCAiU",
+      "uEt3e82IzsK",
+      "zAN1yQdYbcB",
+      "wTJuvXKZCrz",
+      "Z6c1T3O7q0S",
+      "GrZXd4osOGW",
+      "XQajU8YgbXg",
+      "ejraR8DfZPf",
+      "jQ05qNtE9HB",
+      "CPexoOTnUQZ",
+      "BK0kijGEWMy",
+      "EgaLdA1UaEV",
+      "gytTkeQWyoA",
+      "vRh6cPENAgr",
+      "kfQaLeZLepq",
+      "L8r8I4WDRUp"
     ];
 
     dhis2.util.on("dhis2.de.event.dataValuesLoaded", function() {
       $(".comments").toggle(false);
       comments.forEach(function(comment) {
         let $textfield = $("#" + comment + "-Xr12mI7VPn3-val");
-        if ($textfield.val() !== ""){
+        if ($textfield.val() !== "") {
           let commentColumn = $textfield.parent()[0].cellIndex + 1;
           let $tab = "#" + $textfield.closest(".ui-tabs-panel")[0].id;
 
-          $($tab + " table tr > *:nth-child(" + commentColumn + ")").toggle(true);
+          $($tab + " table tr > *:nth-child(" + commentColumn + ")").toggle(
+            true
+          );
         }
       });
     });
@@ -125,14 +183,6 @@
       $($activeTab + " table tr > *:nth-child(" + (col + 1) + ")").toggle();
     });
   });
-
-  function showHideColumn(tab, col) {
-    $(tab + " table tr > *:nth-child(" + col + ")").toggle();
-  }
-
-  function showColumn(tab, col) {
-    $(tab + " table tr > *:nth-child(" + col + ")").toggle(true);
-  }
 </script>
 <style type="text/css">
   #cde table {
@@ -157,7 +207,7 @@
     background-color: #e0e0e0;
   }
 
-  .comments textarea{
+  .comments textarea {
     text-align: left;
   }
 </style>
@@ -584,7 +634,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="xIdJZgy5GSy-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on mechanisms for accreditation of education and training institutions and their programmes Medical Doctor"
+                value="[ Comment of existence of national standard on mechanisms for accreditation of education and training institutions and their programmes Medical Doctor ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -613,7 +670,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="oTTeFlxkljB-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on mechanism on social accountability Medical Doctors"
+                value="[ Comment of existence of national standard on mechanism on social accountability Medical Doctors ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -642,7 +706,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="TVuwNm1PyRC-Xr12mI7VPn3-val"
+                title="Comment of effective implementation of national standards on social accountability Medical Doctors"
+                value="[ Comment of effective implementation of national standards on social accountability Medical Doctors ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -671,7 +742,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="SUvvKWCJO5S-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard for considering social determinants of health accreditation for Medical Doctors"
+                value="[ Comment of existence of national standard for considering social determinants of health accreditation for Medical Doctors ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -700,7 +778,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="GRpQAAvLFM6-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on interprofessional education in accreditation standards Medical Doctors"
+                value="[ Comment of existence of national standard on interprofessional education in accreditation standards Medical Doctors ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -729,7 +814,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="Bvwo2Tnwg6K-Xr12mI7VPn3-val"
+                title="Comment of Existence of cooperation between education and training institutions and health professional regulators to agree on the standards Medical Doctors"
+                value="[ Comment of Existence of cooperation between education and training institutions and health professional regulators to agree on the standards Medical Doctors ]"
+              >
+              </textarea>
             </td>
           </tr>
           <tr>
@@ -766,7 +858,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="BAYPJS2PaYa-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on mechanisms for accreditation of education and training institutions and their programmes General Medical Practitioner"
+                value="[ Comment of existence of national standard on mechanisms for accreditation of education and training institutions and their programmes General Medical Practitioner ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -795,7 +894,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="AuztI35M2eU-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on mechanism on social accountability General Medical Practitioner"
+                value="[ Comment of existence of national standard on mechanism on social accountability General Medical Practitioner ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -824,7 +930,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="CHeEETUlnlu-Xr12mI7VPn3-val"
+                title="Comment of effective implementation of national standards on social accountability General Medical Practitioner"
+                value="[ Comment of effective implementation of national standards on social accountability General Medical Practitioner ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -853,7 +966,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="hUTcFeRUFve-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard for considering social determinants of health accreditation for Generalist Medical Practitioner"
+                value="[ Comment of existence of national standard for considering social determinants of health accreditation for Generalist Medical Practitioner ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -882,7 +1002,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="aNkwiAZwM7f-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on interprofessional education in accreditation standards Generalist Medical Practitioner"
+                value="[ Comment of existence of national standard on interprofessional education in accreditation standards Generalist Medical Practitioner ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -911,7 +1038,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="adhcUwpwjrt-Xr12mI7VPn3-val"
+                title="Comment of existence of cooperation between education and training institutions and health professional regulators to agree on the standards General Medical Practitioner"
+                value="[ Comment of existence of cooperation between education and training institutions and health professional regulators to agree on the standards General Medical Practitioner ]"
+              >
+              </textarea>
             </td>
           </tr>
           <tr>
@@ -948,7 +1082,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="EUuaZTsVCUP-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on mechanisms for accreditation of education and training institutions and their programmes Specialist Medical Practitioner"
+                value="[ Comment of existence of national standard on mechanisms for accreditation of education and training institutions and their programmes Specialist Medical Practitioner ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -977,7 +1118,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="HHu5mmkn9nI-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on mechanism on social accountability Specialist Medical Practitioner"
+                value="[ Comment of existence of national standard on mechanism on social accountability Specialist Medical Practitioner ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1006,7 +1154,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="SvnuCPrV3m8-Xr12mI7VPn3-val"
+                title="Comment of effective implementation of national standards on social accountability Specialist Medical Practitioner"
+                value="[ Comment of effective implementation of national standards on social accountability Specialist Medical Practitioner ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1035,7 +1190,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="M09xmOtGx9r-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard for considering social determinants of health accreditation for Specialist Medical Practitioner"
+                value="[ Comment of existence of national standard for considering social determinants of health accreditation for Specialist Medical Practitioner ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1064,7 +1226,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="W1nqjNXF8t7-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on interprofessional education in accreditation standards Specialist Medical Practitioner"
+                value="[ Comment of existence of national standard for considering social determinants of health accreditation for Specialist Medical Practitioner ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1093,7 +1262,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="vVPyD60zs2c-Xr12mI7VPn3-val"
+                title="Comment of existence of cooperation between education and training institutions and health professional regulators to agree on the standards Specialist Medical Practitioner"
+                value="[ Comment of existence of cooperation between education and training institutions and health professional regulators to agree on the standards Specialist Medical Practitioner ]"
+              >
+              </textarea>
             </td>
           </tr>
           <tr>
@@ -1126,7 +1302,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="qDrIfDpZQzJ-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on mechanisms for accreditation of education and training institutions and their programmes Nursing Professional"
+                value="[ Comment of existence of national standard on mechanisms for accreditation of education and training institutions and their programmes Nursing Professional ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1155,7 +1338,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="oBOgUPGLDM8-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on mechanism on social accountability Nursing Professional"
+                value="[ Comment of existence of national standard on mechanism on social accountability Nursing Professional ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1184,7 +1374,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="K9YrD3rxhIm-Xr12mI7VPn3-val"
+                title="Comment of effective implementation of national standards on social accountability Nursing Professional"
+                value="[ Comment of effective implementation of national standards on social accountability Nursing Professional ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1213,7 +1410,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="s6Rrf01L045-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard for considering social determinants of health accreditation for Nursing Professional"
+                value="[ Comment of existence of national standard for considering social determinants of health accreditation for Nursing Professional ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1242,7 +1446,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="KI35YVBqwOH-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on interprofessional education in accreditation standards Nursing Professional"
+                value="[ Comment of existence of national standard on interprofessional education in accreditation standards Nursing Professional ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1271,7 +1482,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="Iz9uNISIBW5-Xr12mI7VPn3-val"
+                title="Comment of existence of cooperation between education and training institutions and health professional regulators to agree on the standards Nursing Professional"
+                value="[ Comment of existence of cooperation between education and training institutions and health professional regulators to agree on the standards Nursing Professional ]"
+              >
+              </textarea>
             </td>
           </tr>
           <tr>
@@ -1304,7 +1522,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="BABcY9z1yhJ-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on mechanisms for accreditation of education and training institutions and their programmes Midwifery Professional"
+                value="[ Comment of existence of national standard on mechanisms for accreditation of education and training institutions and their programmes Midwifery Professional ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1333,7 +1558,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="kf5mAEgzRro-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on mechanism on social accountability Midwifery Professional"
+                value="[ Comment of existence of national standard on mechanism on social accountability Midwifery Professional ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1362,7 +1594,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="Px7yHDZGBQS-Xr12mI7VPn3-val"
+                title="Comment of effective implementation of national standards on social accountability Midwifery Professional"
+                value="[ Comment of effective implementation of national standards on social accountability Midwifery Professional ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1391,7 +1630,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="Jo5JCqQn6a4-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard for considering social determinants of health accreditation for Midwifery Professional"
+                value="[ Comment of existence of national standard for considering social determinants of health accreditation for Midwifery Professional ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1420,7 +1666,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="HfUw03ynsgX-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on interprofessional education in accreditation standards Midwifery Professional"
+                value="[Comment of existence of national standard on interprofessional education in accreditation standards Midwifery Professional ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1449,7 +1702,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="FbLuOUxYtvW-Xr12mI7VPn3-val"
+                title="Comment of existence of cooperation between education and training institutions and health professional regulators to agree on the standards Midwifery Professional"
+                value="[Comment of existence of cooperation between education and training institutions and health professional regulators to agree on the standards Midwifery Professional ]"
+              >
+              </textarea>
             </td>
           </tr>
           <tr>
@@ -1482,7 +1742,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="sIxOvk6qfU2-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on mechanisms for accreditation of education and training institutions and their programmes Dentist"
+                value="[ Comment of existence of national standard on mechanisms for accreditation of education and training institutions and their programmes Dentist ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1511,7 +1778,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="dNdiNzgxEAO-Xr12mI7VPn3-val"
+                title="Comment of Existence of national standard on mechanism on social accountability Dentist"
+                value="[ Comment of Existence of national standard on mechanism on social accountability Dentist ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1540,7 +1814,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="H7lhdWUUWxH-Xr12mI7VPn3-val"
+                title="Comment of Effective implementation of national standards on social accountability Dentist"
+                value="[ Comment of Effective implementation of national standards on social accountability Dentist ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1569,7 +1850,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="grFSq6NI6Rv-Xr12mI7VPn3-val"
+                title="Comment of Existence of national standard for considering social determinants of health accreditation for Dentist"
+                value="[ Comment of Existence of national standard for considering social determinants of health accreditation for Dentist ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1598,7 +1886,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="d5tEbnmf2Yl-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on interprofessional education in accreditation standards Dentist"
+                value="[ Comment of existence of national standard on interprofessional education in accreditation standards Dentist ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1627,7 +1922,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="zJNTztzEUjf-Xr12mI7VPn3-val"
+                title="Comment of Existence of cooperation between education and training institutions and health professional regulators to agree on the standards Dentist"
+                value="[ Comment of Existence of cooperation between education and training institutions and health professional regulators to agree on the standards Dentist ]"
+              >
+              </textarea>
             </td>
           </tr>
           <tr>
@@ -1660,7 +1962,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="klUdBljsnYT-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on mechanisms for accreditation of education and training institutions and their programmes Pharmacist"
+                value="[ Comment of existence of national standard on mechanisms for accreditation of education and training institutions and their programmes Pharmacist ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1689,7 +1998,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="Ye7wRY6LeT4-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on mechanism on social accountability Pharmacist"
+                value="[ Comment of existence of national standard on mechanism on social accountability Pharmacist ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1718,7 +2034,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="OJ2BPEwWYG9-Xr12mI7VPn3-val"
+                title="Comment of effective implementation of national standards on social accountability Pharmacist"
+                value="[ Comment of effective implementation of national standards on social accountability Pharmacist ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1747,7 +2070,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="el5QnfrCW5R-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard for considering social determinants of health accreditation for Pharmacist"
+                value="[ Comment of existence of national standard for considering social determinants of health accreditation for Pharmacist ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1776,7 +2106,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="w3Lz42yCAiU-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on interprofessional education in accreditation standards Pharmacist"
+                value="[ Comment of existence of national standard on interprofessional education in accreditation standards Pharmacist ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1805,7 +2142,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="uEt3e82IzsK-Xr12mI7VPn3-val"
+                title="Comment of Existence of cooperation between education and training institutions and health professional regulators to agree on the standards Pharmacist"
+                value="[ Comment of Existence of cooperation between education and training institutions and health professional regulators to agree on the standards Pharmacist ]"
+              >
+              </textarea>
             </td>
           </tr>
         </thead>
@@ -1873,7 +2217,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="zAN1yQdYbcB-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard for Continuing Professional Development for Medical Doctors"
+                value="[ Comment of existence of national standard for Continuing Professional Development for Medical Doctors ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1902,7 +2253,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="wTJuvXKZCrz-Xr12mI7VPn3-val"
+                title="Comment of existence of in-service training as an element of national education plans for the health workforce Medical Doctorss"
+                value="[ Comment of existence of in-service training as an element of national education plans for the health workforce Medical Doctors ]"
+              >
+              </textarea>
             </td>
           </tr>
           <tr>
@@ -1939,7 +2297,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="Z6c1T3O7q0S-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard for Continuing Professional Development for General Medical Practitioner"
+                value="[ Comment of existence of national standard for Continuing Professional Development for General Medical Practitioner ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1968,7 +2333,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="GrZXd4osOGW-Xr12mI7VPn3-val"
+                title="Comment of existence of in-service training as an element of national education plans for the health workforce General Medical Practitioner"
+                value="[ Comment of existence of in-service training as an element of national education plans for the health workforce General Medical Practitioner ]"
+              >
+              </textarea>
             </td>
           </tr>
           <tr>
@@ -2005,7 +2377,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="XQajU8YgbXg-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard for Continuing Professional Development for Specialist Medical Practitioner"
+                value="[ Comment of existence of national standard for Continuing Professional Development for Specialist Medical Practitioner ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -2034,7 +2413,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="ejraR8DfZPf-Xr12mI7VPn3-val"
+                title="Comment of existence of in-service training as an element of national education plans for the health workforce Specialist Medical Practitioner"
+                value="[ Comment of existence of in-service training as an element of national education plans for the health workforce Specialist Medical Practitioner ]"
+              >
+              </textarea>
             </td>
           </tr>
           <tr>
@@ -2067,7 +2453,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="jQ05qNtE9HB-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard for Continuing Professional Development for Nursing Professional"
+                value="[ Comment of existence of national standard for Continuing Professional Development for Nursing Professional ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -2096,7 +2489,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="CPexoOTnUQZ-Xr12mI7VPn3-val"
+                title="Comment of existence of in-service training as an element of national education plans for the health workforce Nursing Professional"
+                value="[ Comment of existence of in-service training as an element of national education plans for the health workforce Nursing Professional ]"
+              >
+              </textarea>
             </td>
           </tr>
           <tr>
@@ -2129,7 +2529,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="BK0kijGEWMy-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard for Continuing Professional Development for Midwifery Professional"
+                value="[ Comment of existence of national standard for Continuing Professional Development for Midwifery Professional ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -2158,7 +2565,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="EgaLdA1UaEV-Xr12mI7VPn3-val"
+                title="Comment of existence of in-service training as an element of national education plans for the health workforce Midwifery Professional"
+                value="[ Comment of existence of in-service training as an element of national education plans for the health workforce Midwifery Professional ]"
+              >
+              </textarea>
             </td>
           </tr>
           <tr>
@@ -2191,7 +2605,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="gytTkeQWyoA-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard for Continuing Professional Development for Dentist"
+                value="[ Comment of existence of national standard for Continuing Professional Development for Dentist ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -2220,7 +2641,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="vRh6cPENAgr-Xr12mI7VPn3-val"
+                title="Comment of existence of in-service training as an element of national education plans for the health workforce Dentist"
+                value="[ Comment of existence of in-service training as an element of national education plans for the health workforce Dentist ]"
+              >
+              </textarea>
             </td>
           </tr>
           <tr>
@@ -2253,7 +2681,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="kfQaLeZLepq-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard for Continuing Professional Development for Pharmacist"
+                value="[ Comment of existence of national standard for Continuing Professional Development for Pharmacist ]"
+              >
+              </textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -2282,7 +2717,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="L8r8I4WDRUp-Xr12mI7VPn3-val"
+                title="Comment of existence of in-service training as an element of national education plans for the health workforce Pharmacist"
+                value="[ Comment of existence of in-service training as an element of national education plans for the health workforce Pharmacist ]"
+              >
+              </textarea>
             </td>
           </tr>
         </thead>

--- a/HWF/Custom_forms/NHWA Module 3 (gUsLcRFoCG6).html
+++ b/HWF/Custom_forms/NHWA Module 3 (gUsLcRFoCG6).html
@@ -90,6 +90,17 @@
         });
       });
     });
+
+    $(".comment-bubble").on("click", function() {
+      let $activeTab = $(".ui-tabs-active > a")[0].hash;
+
+      console.log("Active tab: " + $activeTab);
+
+      let col = $(this).parent()[0].cellIndex + 1;
+
+      console.log("Active col: " +col);
+      $($activeTab + " table tr > *:nth-child(" + (col +1) + ")").toggle();
+    });
   });
 </script>
 <style type="text/css">
@@ -156,6 +167,7 @@
                 and training (3-01)</b
               >
             </th>
+            <th></th>
           </tr>
           <tr>
             <td>1</td>
@@ -185,6 +197,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
           </tr>
           <tr>
@@ -220,6 +235,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
           </tr>
           <tr>
             <td>3</td>
@@ -254,6 +272,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
           </tr>
           <tr>
             <td>4</td>
@@ -283,6 +304,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
           </tr>
           <tr>
@@ -314,6 +338,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
           </tr>
           <tr>
             <td>6</td>
@@ -343,6 +370,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
           </tr>
           <tr>
@@ -374,6 +404,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
           </tr>
         </thead>
         <tbody></tbody>
@@ -398,24 +431,30 @@
               for accreditation of education and training institutions<br />
               and their programmes, by programme, by occupation (3-02)
             </th>
+            <th></th>
             <th style="text-align: center;">
               Existence of national and/or subnational mechanism<br />
               on social accountability in accreditation (3-03)
             </th>
+            <th></th>
             <th style="text-align: center;">Effective implementation (3-04)</th>
+            <th></th>
             <th style="text-align: center;">
               Existence of national and/or sub-national standards<br />
               for the Social Determinants of Health (3-05)
             </th>
+            <th></th>
             <th style="text-align: center;">
               Existence of national and/or sub-national standards on<br />
               interprofessional education in accreditation standards (3-06)
             </th>
+            <th></th>
             <th style="text-align: center;">
               Existence of cooperation between education and training<br />
               institutions and health professional regulators to agree on the
               standards (3-07)
             </th>
+            <th></th>
           </tr>
           <tr>
             <td>1</td>
@@ -446,6 +485,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="aEDrisPWh6i-I93t0K7b1oN-val"
@@ -471,6 +513,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -498,6 +543,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="U5S2sbEnGT9-I93t0K7b1oN-val"
@@ -523,6 +571,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -550,6 +601,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="j4pHY4ToKPi-I93t0K7b1oN-val"
@@ -575,6 +629,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
           </tr>
           <tr>
@@ -610,6 +667,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="KcDPaDGLf9P-I93t0K7b1oN-val"
@@ -635,6 +695,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -662,6 +725,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="o64uNjIuRXr-I93t0K7b1oN-val"
@@ -687,6 +753,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -714,6 +783,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="Mx06wOF9Edi-I93t0K7b1oN-val"
@@ -739,6 +811,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
           </tr>
           <tr>
@@ -774,6 +849,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="zHNwRzmyOeL-I93t0K7b1oN-val"
@@ -799,6 +877,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -826,6 +907,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="XQgL1GHsnrT-I93t0K7b1oN-val"
@@ -851,6 +935,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -878,6 +965,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="hJJOo4gRjQA-I93t0K7b1oN-val"
@@ -903,6 +993,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
           </tr>
           <tr>
@@ -934,6 +1027,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="PE5XG7ZZgdc-I93t0K7b1oN-val"
@@ -959,6 +1055,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -986,6 +1085,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="Dn2P7GXFCTr-I93t0K7b1oN-val"
@@ -1011,6 +1113,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1038,6 +1143,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="GNErbB4poQO-I93t0K7b1oN-val"
@@ -1063,6 +1171,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
           </tr>
           <tr>
@@ -1094,6 +1205,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="qZ9h4jv9cgO-I93t0K7b1oN-val"
@@ -1119,6 +1233,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1146,6 +1263,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="pnySnJ6om1A-I93t0K7b1oN-val"
@@ -1171,6 +1291,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1198,6 +1321,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="bq7cDa5kIgG-I93t0K7b1oN-val"
@@ -1223,6 +1349,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
           </tr>
           <tr>
@@ -1254,6 +1383,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="TdnUj1l3Z4i-I93t0K7b1oN-val"
@@ -1279,6 +1411,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1306,6 +1441,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="fhe12emlYec-I93t0K7b1oN-val"
@@ -1331,6 +1469,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1358,6 +1499,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="Fu0P8tj6k3M-I93t0K7b1oN-val"
@@ -1383,6 +1527,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
           </tr>
           <tr>
@@ -1414,6 +1561,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="WsHpge8yVZM-I93t0K7b1oN-val"
@@ -1439,6 +1589,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1466,6 +1619,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="wTTVz32PAOn-I93t0K7b1oN-val"
@@ -1491,6 +1647,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
             <td style="text-align: center;">
               <input
@@ -1518,6 +1677,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="v6O0oWTXY34-I93t0K7b1oN-val"
@@ -1544,6 +1706,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
           </tr>
         </thead>
         <tbody></tbody>
@@ -1569,10 +1734,12 @@
               Existence of national and/or subnational mechanism<br />
               on continuing professional development (3-08)
             </th>
+            <th></th>
             <th style="text-align: center;">
               Existence of in-service training as an element of<br />
               national education plans for health workers (3-09)
             </th>
+            <th></th>
           </tr>
           <tr>
             <td>1</td>
@@ -1603,6 +1770,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="m8xYEbXD3Ee-I93t0K7b1oN-val"
@@ -1628,6 +1798,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
           </tr>
           <tr>
@@ -1663,6 +1836,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="pWAGDlaDi7y-I93t0K7b1oN-val"
@@ -1688,6 +1864,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
           </tr>
           <tr>
@@ -1723,6 +1902,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="H4L8KbENVVk-I93t0K7b1oN-val"
@@ -1748,6 +1930,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
           </tr>
           <tr>
@@ -1779,6 +1964,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="KPlsuTaezlc-I93t0K7b1oN-val"
@@ -1804,6 +1992,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
           </tr>
           <tr>
@@ -1835,6 +2026,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="Pf77Sb5TYCR-I93t0K7b1oN-val"
@@ -1860,6 +2054,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
           </tr>
           <tr>
@@ -1891,6 +2088,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="LJNl2upvs8S-I93t0K7b1oN-val"
@@ -1916,6 +2116,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
           </tr>
           <tr>
@@ -1947,6 +2150,9 @@
                 style="cursor: pointer; margin-left: 10px;"
               />
             </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
+            </td>
             <td style="text-align: center;">
               <input
                 id="vKV2AVBhstz-I93t0K7b1oN-val"
@@ -1972,6 +2178,9 @@
                 title="View comment"
                 style="cursor: pointer; margin-left: 10px;"
               />
+            </td>
+            <td class="comments" scope="row" style="text-align: center;">
+              <textarea name="entryfield" id=""></textarea>
             </td>
           </tr>
         </thead>

--- a/HWF/Custom_forms/NHWA Module 3 (gUsLcRFoCG6).html
+++ b/HWF/Custom_forms/NHWA Module 3 (gUsLcRFoCG6).html
@@ -174,12 +174,7 @@
 
     $(".comment-bubble").on("click", function() {
       let $activeTab = $(".ui-tabs-active > a")[0].hash;
-
-      console.log("Active tab: " + $activeTab);
-
       let col = $(this).parent()[0].cellIndex + 1;
-
-      console.log("Active col: " + col);
       $($activeTab + " table tr > *:nth-child(" + (col + 1) + ")").toggle();
     });
   });

--- a/HWF/Custom_forms/NHWA Module 3 (gUsLcRFoCG6).html
+++ b/HWF/Custom_forms/NHWA Module 3 (gUsLcRFoCG6).html
@@ -91,6 +91,29 @@
       });
     });
 
+    var comments = [
+      "slfNDnwGD4i",
+      "KM3j2qURZvm",
+      "IRewF07UDgW",
+      "IS6oWwtsElu",
+      "S0cJazBoB9r",
+      "ZVZnw9CazmI",
+      "RBkF8N37tQl"
+    ];
+
+    dhis2.util.on("dhis2.de.event.dataValuesLoaded", function() {
+      $(".comments").toggle(false);
+      comments.forEach(function(comment) {
+        let $textfield = $("#" + comment + "-Xr12mI7VPn3-val");
+        if ($textfield.val() !== ""){
+          let commentColumn = $textfield.parent()[0].cellIndex + 1;
+          let $tab = "#" + $textfield.closest(".ui-tabs-panel")[0].id;
+
+          $($tab + " table tr > *:nth-child(" + commentColumn + ")").toggle(true);
+        }
+      });
+    });
+
     $(".comment-bubble").on("click", function() {
       let $activeTab = $(".ui-tabs-active > a")[0].hash;
 
@@ -98,10 +121,18 @@
 
       let col = $(this).parent()[0].cellIndex + 1;
 
-      console.log("Active col: " +col);
-      $($activeTab + " table tr > *:nth-child(" + (col +1) + ")").toggle();
+      console.log("Active col: " + col);
+      $($activeTab + " table tr > *:nth-child(" + (col + 1) + ")").toggle();
     });
   });
+
+  function showHideColumn(tab, col) {
+    $(tab + " table tr > *:nth-child(" + col + ")").toggle();
+  }
+
+  function showColumn(tab, col) {
+    $(tab + " table tr > *:nth-child(" + col + ")").toggle(true);
+  }
 </script>
 <style type="text/css">
   #cde table {
@@ -124,6 +155,10 @@
 
   .cde-greyfield {
     background-color: #e0e0e0;
+  }
+
+  .comments textarea{
+    text-align: left;
   }
 </style>
 <h3 style="text-align: center;">
@@ -167,7 +202,9 @@
                 and training (3-01)</b
               >
             </th>
-            <th></th>
+            <th class="comments" scope="row" style="text-align: center;">
+              Comment
+            </th>
           </tr>
           <tr>
             <td>1</td>
@@ -199,7 +236,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="slfNDnwGD4i-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on the duration and contents of education and training for General Medical Practitioner"
+                value="[ Comment of existence of national standard on the duration and contents of education and training for General Medical Practitioner ]"
+              >
+              </textarea>
             </td>
           </tr>
           <tr>
@@ -236,7 +280,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="KM3j2qURZvm-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on the duration and contents of education and training for General Medical Practitioner"
+                value="[ Comment of existence of national standard on the duration and contents of education and training for General Medical Practitioner ]"
+              >
+              </textarea>
             </td>
           </tr>
           <tr>
@@ -273,7 +324,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="IRewF07UDgW-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on the duration and contents of education and training for Specialist Medical Practitioner"
+                value="[ Comment of existence of national standard on the duration and contents of education and training for Specialist Medical Practitioner ]"
+              >
+              </textarea>
             </td>
           </tr>
           <tr>
@@ -306,7 +364,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="IS6oWwtsElu-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on the duration and contents of education and training for Nursing Professional"
+                value="[ Comment of existence of national standard on the duration and contents of education and training for Nursing Professional ]"
+              >
+              </textarea>
             </td>
           </tr>
           <tr>
@@ -339,7 +404,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="S0cJazBoB9r-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on the duration and contents of education and training for Midwifery Professional"
+                value="[ Comment of existence of national standard on the duration and contents of education and training for Midwifery Professional ]"
+              >
+              </textarea>
             </td>
           </tr>
           <tr>
@@ -372,7 +444,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="ZVZnw9CazmI-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on the duration and contents of education and training for Dentist"
+                value="[ Comment of existence of national standard on the duration and contents of education and training for Dentist ]"
+              >
+              </textarea>
             </td>
           </tr>
           <tr>
@@ -405,7 +484,14 @@
               />
             </td>
             <td class="comments" scope="row" style="text-align: center;">
-              <textarea name="entryfield" id=""></textarea>
+              <textarea
+                name="entryfield"
+                class="entryfield"
+                id="RBkF8N37tQl-Xr12mI7VPn3-val"
+                title="Comment of existence of national standard on the duration and contents of education and training for Pharmacist"
+                value="[ Comment of existence of national standard on the duration and contents of education and training for Pharmacist ]"
+              >
+              </textarea>
             </td>
           </tr>
         </thead>
@@ -431,30 +517,42 @@
               for accreditation of education and training institutions<br />
               and their programmes, by programme, by occupation (3-02)
             </th>
-            <th></th>
+            <th class="comments" scope="row" style="text-align: center;">
+              Comment
+            </th>
             <th style="text-align: center;">
               Existence of national and/or subnational mechanism<br />
               on social accountability in accreditation (3-03)
             </th>
-            <th></th>
+            <th class="comments" scope="row" style="text-align: center;">
+              Comment
+            </th>
             <th style="text-align: center;">Effective implementation (3-04)</th>
-            <th></th>
+            <th class="comments" scope="row" style="text-align: center;">
+              Comment
+            </th>
             <th style="text-align: center;">
               Existence of national and/or sub-national standards<br />
               for the Social Determinants of Health (3-05)
             </th>
-            <th></th>
+            <th class="comments" scope="row" style="text-align: center;">
+              Comment
+            </th>
             <th style="text-align: center;">
               Existence of national and/or sub-national standards on<br />
               interprofessional education in accreditation standards (3-06)
             </th>
-            <th></th>
+            <th class="comments" scope="row" style="text-align: center;">
+              Comment
+            </th>
             <th style="text-align: center;">
               Existence of cooperation between education and training<br />
               institutions and health professional regulators to agree on the
               standards (3-07)
             </th>
-            <th></th>
+            <th class="comments" scope="row" style="text-align: center;">
+              Comment
+            </th>
           </tr>
           <tr>
             <td>1</td>
@@ -1734,12 +1832,16 @@
               Existence of national and/or subnational mechanism<br />
               on continuing professional development (3-08)
             </th>
-            <th></th>
+            <th class="comments" scope="row" style="text-align: center;">
+              Comment
+            </th>
             <th style="text-align: center;">
               Existence of in-service training as an element of<br />
               national education plans for health workers (3-09)
             </th>
-            <th></th>
+            <th class="comments" scope="row" style="text-align: center;">
+              Comment
+            </th>
           </tr>
           <tr>
             <td>1</td>

--- a/HWF/Custom_forms/NHWA Module 3 (gUsLcRFoCG6).html
+++ b/HWF/Custom_forms/NHWA Module 3 (gUsLcRFoCG6).html
@@ -108,6 +108,7 @@
     height: 30px;
     padding: 10px;
     margin: 10px;
+    min-width: 170px;
   }
 
   .cde-greyfield {
@@ -178,6 +179,12 @@
                 title="undefined"
                 value="[ undefined ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
           </tr>
           <tr>
@@ -206,6 +213,12 @@
                 title="Existence of national standard on the duration and contents of education and training for General Medical Practitioner No"
                 value="[ Existence of national standard on the duration and contents of education and training for General Medical Practitioner No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
           </tr>
           <tr>
@@ -234,6 +247,12 @@
                 title="Existence of national standard on the duration and contents of education and training for Specialist Medical Practitioner No"
                 value="[ Existence of national standard on the duration and contents of education and training for Specialist Medical Practitioner No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
           </tr>
           <tr>
@@ -258,6 +277,12 @@
                 title="Existence of national standard on the duration and contents of education and training for Nursing Professional No"
                 value="[ Existence of national standard on the duration and contents of education and training for Nursing Professional No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
           </tr>
           <tr>
@@ -282,6 +307,12 @@
                 title="Existence of national standard on the duration and contents of education and training for Midwifery Professional No"
                 value="[ Existence of national standard on the duration and contents of education and training for Midwifery Professional No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
           </tr>
           <tr>
@@ -306,6 +337,12 @@
                 title="Existence of national standard on the duration and contents of education and training for Dentist No"
                 value="[ Existence of national standard on the duration and contents of education and training for Dentist No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
           </tr>
           <tr>
@@ -330,6 +367,12 @@
                 title="Existence of national standard on the duration and contents of education and training for Pharmacist No"
                 value="[ Existence of national standard on the duration and contents of education and training for Pharmacist No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
           </tr>
         </thead>
@@ -396,6 +439,12 @@
                 title="undefined"
                 value="[ undefined ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -416,6 +465,12 @@
                 title="undefined"
                 value="[ undefined ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -436,6 +491,12 @@
                 title="undefined"
                 value="[ undefined ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -456,6 +517,12 @@
                 title="undefined"
                 value="[ undefined ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -476,6 +543,12 @@
                 title="undefined"
                 value="[ undefined ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -496,6 +569,12 @@
                 title="undefined"
                 value="[ undefined ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
           </tr>
           <tr>
@@ -524,6 +603,12 @@
                 title="Existence of national standard on mechanisms for accreditation of education and training institutions and their programmes General Medical Practitioner No"
                 value="[ Existence of national standard on mechanisms for accreditation of education and training institutions and their programmes General Medical Practitioner No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -544,6 +629,12 @@
                 title="Existence of national standard on mechanism on social accountability General Medical Practitioner No"
                 value="[ Existence of national standard on mechanism on social accountability General Medical Practitioner No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -564,6 +655,12 @@
                 title="Effective implementation of national standards on social accountability General Medical Practitioner No"
                 value="[ Effective implementation of national standards on social accountability General Medical Practitioner No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -584,6 +681,12 @@
                 title="Existence of national standard for considering social determinants of health accreditation for Generalist Medical Practitioner No"
                 value="[ Existence of national standard for considering social determinants of health accreditation for Generalist Medical Practitioner No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -604,6 +707,12 @@
                 title="Existence of national standard on interprofessional education in accreditation standards Generalist Medical Practitioner No"
                 value="[ Existence of national standard on interprofessional education in accreditation standards Generalist Medical Practitioner No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -624,6 +733,12 @@
                 title="Existence of cooperation between education and training institutions and health professional regulators to agree on the standards General Medical Practitioner No"
                 value="[ Existence of cooperation between education and training institutions and health professional regulators to agree on the standards General Medical Practitioner No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
           </tr>
           <tr>
@@ -652,6 +767,12 @@
                 title="Existence of national standard on mechanisms for accreditation of education and training institutions and their programmes Specialist Medical Practitioner No"
                 value="[ Existence of national standard on mechanisms for accreditation of education and training institutions and their programmes Specialist Medical Practitioner No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -672,6 +793,12 @@
                 title="Existence of national standard on mechanism on social accountability Specialist Medical Practitioner No"
                 value="[ Existence of national standard on mechanism on social accountability Specialist Medical Practitioner No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -692,6 +819,12 @@
                 title="Effective implementation of national standards on social accountability Specialist Medical Practitioner No"
                 value="[ Effective implementation of national standards on social accountability Specialist Medical Practitioner No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -712,6 +845,12 @@
                 title="Existence of national standard for considering social determinants of health accreditation for Specialist Medical Practitioner No"
                 value="[ Existence of national standard for considering social determinants of health accreditation for Specialist Medical Practitioner No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -732,6 +871,12 @@
                 title="Existence of national standard on interprofessional education in accreditation standards Specialist Medical Practitioner No"
                 value="[ Existence of national standard on interprofessional education in accreditation standards Specialist Medical Practitioner No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -752,6 +897,12 @@
                 title="Existence of cooperation between education and training institutions and health professional regulators to agree on the standards Specialist Medical Practitioner No"
                 value="[ Existence of cooperation between education and training institutions and health professional regulators to agree on the standards Specialist Medical Practitioner No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
           </tr>
           <tr>
@@ -776,6 +927,12 @@
                 title="Existence of national standard on mechanisms for accreditation of education and training institutions and their programmes Nursing Professional No"
                 value="[ Existence of national standard on mechanisms for accreditation of education and training institutions and their programmes Nursing Professional No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -796,6 +953,12 @@
                 title="Existence of national standard on mechanism on social accountability Nursing Professional No"
                 value="[ Existence of national standard on mechanism on social accountability Nursing Professional No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -816,6 +979,12 @@
                 title="Effective implementation of national standards on social accountability Nursing Professional No"
                 value="[ Effective implementation of national standards on social accountability Nursing Professional No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -836,6 +1005,12 @@
                 title="Existence of national standard for considering social determinants of health accreditation for Nursing Professional No"
                 value="[ Existence of national standard for considering social determinants of health accreditation for Nursing Professional No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -856,6 +1031,12 @@
                 title="Existence of national standard on interprofessional education in accreditation standards Nursing Professional No"
                 value="[ Existence of national standard on interprofessional education in accreditation standards Nursing Professional No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -876,6 +1057,12 @@
                 title="Existence of cooperation between education and training institutions and health professional regulators to agree on the standards Nursing Professional No"
                 value="[ Existence of cooperation between education and training institutions and health professional regulators to agree on the standards Nursing Professional No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
           </tr>
           <tr>
@@ -900,6 +1087,12 @@
                 title="Existence of national standard on mechanisms for accreditation of education and training institutions and their programmes Midwifery Professional No"
                 value="[ Existence of national standard on mechanisms for accreditation of education and training institutions and their programmes Midwifery Professional No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -920,6 +1113,12 @@
                 title="Existence of national standard on mechanism on social accountability Midwifery Professional No"
                 value="[ Existence of national standard on mechanism on social accountability Midwifery Professional No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -940,6 +1139,12 @@
                 title="Effective implementation of national standards on social accountability Midwifery Professional No"
                 value="[ Effective implementation of national standards on social accountability Midwifery Professional No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -960,6 +1165,12 @@
                 title="Existence of national standard for considering social determinants of health accreditation for Midwifery Professional No"
                 value="[ Existence of national standard for considering social determinants of health accreditation for Midwifery Professional No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -980,6 +1191,12 @@
                 title="Existence of national standard on interprofessional education in accreditation standards Midwifery Professional No"
                 value="[ Existence of national standard on interprofessional education in accreditation standards Midwifery Professional No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -1000,6 +1217,12 @@
                 title="Existence of cooperation between education and training institutions and health professional regulators to agree on the standards Midwifery Professional No"
                 value="[ Existence of cooperation between education and training institutions and health professional regulators to agree on the standards Midwifery Professional No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
           </tr>
           <tr>
@@ -1024,6 +1247,12 @@
                 title="Existence of national standard on mechanisms for accreditation of education and training institutions and their programmes Dentist No"
                 value="[ Existence of national standard on mechanisms for accreditation of education and training institutions and their programmes Dentist No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -1044,6 +1273,12 @@
                 title="Existence of national standard on mechanism on social accountability Dentist No"
                 value="[ Existence of national standard on mechanism on social accountability Dentist No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -1064,6 +1299,12 @@
                 title="Effective implementation of national standards on social accountability Dentist No"
                 value="[ Effective implementation of national standards on social accountability Dentist No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -1084,6 +1325,12 @@
                 title="Existence of national standard for considering social determinants of health accreditation for Dentist No"
                 value="[ Existence of national standard for considering social determinants of health accreditation for Dentist No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -1104,6 +1351,12 @@
                 title="Existence of national standard on interprofessional education in accreditation standards Dentist No"
                 value="[ Existence of national standard on interprofessional education in accreditation standards Dentist No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -1124,6 +1377,12 @@
                 title="Existence of cooperation between education and training institutions and health professional regulators to agree on the standards Dentist No"
                 value="[ Existence of cooperation between education and training institutions and health professional regulators to agree on the standards Dentist No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
           </tr>
           <tr>
@@ -1148,6 +1407,12 @@
                 title="Existence of national standard on mechanisms for accreditation of education and training institutions and their programmes Pharmacist No"
                 value="[ Existence of national standard on mechanisms for accreditation of education and training institutions and their programmes Pharmacist No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -1168,6 +1433,12 @@
                 title="Existence of national standard on mechanism on social accountability Pharmacist No"
                 value="[ Existence of national standard on mechanism on social accountability Pharmacist No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -1188,6 +1459,12 @@
                 title="Effective implementation of national standards on social accountability Pharmacist No"
                 value="[ Effective implementation of national standards on social accountability Pharmacist No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -1208,6 +1485,12 @@
                 title="Existence of national standard for considering social determinants of health accreditation for Pharmacist No"
                 value="[ Existence of national standard for considering social determinants of health accreditation for Pharmacist No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -1228,6 +1511,12 @@
                 title="Existence of national standard on interprofessional education in accreditation standards Pharmacist No"
                 value="[ Existence of national standard on interprofessional education in accreditation standards Pharmacist No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -1248,6 +1537,12 @@
                 title="Existence of cooperation between education and training institutions and health professional regulators to agree on the standards Pharmacist No"
                 value="[ Existence of cooperation between education and training institutions and health professional regulators to agree on the standards Pharmacist No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
           </tr>
         </thead>
@@ -1301,6 +1596,12 @@
                 title="undefined"
                 value="[ undefined ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -1321,6 +1622,12 @@
                 title="undefined"
                 value="[ undefined ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
           </tr>
           <tr>
@@ -1349,6 +1656,12 @@
                 title="Existence of national standard for Continuing Professional Development for General Medical Practitioner No"
                 value="[ Existence of national standard for Continuing Professional Development for General Medical Practitioner No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -1369,6 +1682,12 @@
                 title="Existence of in-service training as an element of national education plans for the health workforce General Medical Practitioner No"
                 value="[ Existence of in-service training as an element of national education plans for the health workforce General Medical Practitioner No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
           </tr>
           <tr>
@@ -1397,6 +1716,12 @@
                 title="Existence of national standard for Continuing Professional Development for Specialist Medical Practitioner No"
                 value="[ Existence of national standard for Continuing Professional Development for Specialist Medical Practitioner No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -1417,6 +1742,12 @@
                 title="Existence of in-service training as an element of national education plans for the health workforce Specialist Medical Practitioner No"
                 value="[ Existence of in-service training as an element of national education plans for the health workforce Specialist Medical Practitioner No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
           </tr>
           <tr>
@@ -1441,6 +1772,12 @@
                 title="Existence of national standard for Continuing Professional Development for Nursing Professional No"
                 value="[ Existence of national standard for Continuing Professional Development for Nursing Professional No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -1461,6 +1798,12 @@
                 title="Existence of in-service training as an element of national education plans for the health workforce Nursing Professional No"
                 value="[ Existence of in-service training as an element of national education plans for the health workforce Nursing Professional No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
           </tr>
           <tr>
@@ -1485,6 +1828,12 @@
                 title="Existence of national standard for Continuing Professional Development for Midwifery Professional No"
                 value="[ Existence of national standard for Continuing Professional Development for Midwifery Professional No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -1505,6 +1854,12 @@
                 title="Existence of in-service training as an element of national education plans for the health workforce Midwifery Professional No"
                 value="[ Existence of in-service training as an element of national education plans for the health workforce Midwifery Professional No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
           </tr>
           <tr>
@@ -1529,6 +1884,12 @@
                 title="Existence of national standard for Continuing Professional Development for Dentist No"
                 value="[ Existence of national standard for Continuing Professional Development for Dentist No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -1549,6 +1910,12 @@
                 title="Existence of in-service training as an element of national education plans for the health workforce Dentist No"
                 value="[ Existence of in-service training as an element of national education plans for the health workforce Dentist No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
           </tr>
           <tr>
@@ -1573,6 +1940,12 @@
                 title="Existence of national standard for Continuing Professional Development for Pharmacist No"
                 value="[ Existence of national standard for Continuing Professional Development for Pharmacist No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
             <td style="text-align: center;">
               <input
@@ -1593,6 +1966,12 @@
                 title="Existence of in-service training as an element of national education plans for the health workforce Pharmacist No"
                 value="[ Existence of in-service training as an element of national education plans for the health workforce Pharmacist No ]"
               />No
+              <img
+                class="comment-bubble"
+                src="../images/comment.png"
+                title="View comment"
+                style="cursor: pointer; margin-left: 10px;"
+              />
             </td>
           </tr>
         </thead>


### PR DESCRIPTION
### :pushpin: References
* **Issue:** close #7            
* **Related pull-requests:** 

### :tophat: What is the goal?

The goal is to add a comment cell in custom form for every yes partial no.
Comments columns should be hidden by default,  To click on a comment icon, the column should be visible and when a custom form load values and comment has value the column should be visible.

### :memo: How is it being implemented?

- I have created a new data element for every yes partial no
- I have modified table in the custom form to add comments columns
- I have modified scripts to add visible hide logic for comments columns

### :boom: How can it be tested?

From Data entry application selected module 3 data set.

[package data set module 3](https://github.com/EyeSeeTea/WHO-packages/files/3656085/module3-metadata.zip)

